### PR TITLE
Add JobTrackr CLI, SQLite backend, tests, packaging, and README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.db
+*.sqlite3
+*.csv
+.pytest_cache/
+.DS_Store
+.env
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,76 @@
-Hello I am Abhigyan and this is the first github thing I have tried.
-Hello I am Arpit tmcc.
+# JobTrackr CLI
+
+A lightweight, portfolio-ready Python CLI app for tracking job applications using SQLite.
+
+## Why this project looks good on a resume
+
+- **Real-world problem**: manage applications, statuses, and timelines.
+- **Production-style structure**: modular package, tests, and clear CLI interface.
+- **No heavy dependencies**: built with Python standard library (`argparse`, `sqlite3`, `csv`).
+- **Data portability**: export your tracker data to CSV.
+
+## Features
+
+- Initialize a local SQLite database
+- Add job applications with metadata (company, role, status, date, notes)
+- List applications with optional filters
+- View status statistics
+- Export all records to CSV
+
+## Quickstart
+
+```bash
+python -m jobtrackr.cli init
+python -m jobtrackr.cli add --company "OpenAI" --role "Software Engineer" --status applied --date 2026-04-03 --notes "Applied via careers page"
+python -m jobtrackr.cli list
+python -m jobtrackr.cli stats
+python -m jobtrackr.cli export --output applications.csv
+```
+
+You can optionally choose a custom DB location:
+
+```bash
+python -m jobtrackr.cli --db ./data/my_jobs.db init
+```
+
+## Commands
+
+### `init`
+Creates the applications table if it doesn't exist.
+
+### `add`
+Required:
+- `--company`
+- `--role`
+
+Optional:
+- `--status` (`wishlist`, `applied`, `interview`, `offer`, `rejected`) default: `applied`
+- `--date` (YYYY-MM-DD) default: today
+- `--notes`
+
+### `list`
+Optional filters:
+- `--status` one of valid statuses
+- `--since` date in YYYY-MM-DD (show applications on or after this date)
+
+### `stats`
+Shows total applications and count by status.
+
+### `export`
+- `--output` path to CSV file (default: `applications_export.csv`)
+
+## Run tests
+
+```bash
+python -m unittest discover -s tests -v
+```
+
+## Repository name suggestion
+
+A strong name for GitHub and resume use:
+
+- **`jobtrackr-cli`** (recommended)
+- `job-application-tracker`
+- `career-pipeline-cli`
+
+If you want, I can also prepare a one-line resume bullet for this project.

--- a/jobtrackr/__init__.py
+++ b/jobtrackr/__init__.py
@@ -1,0 +1,3 @@
+"""JobTrackr package."""
+
+__all__ = ["cli", "db"]

--- a/jobtrackr/cli.py
+++ b/jobtrackr/cli.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+from jobtrackr.db import (
+    VALID_STATUSES,
+    add_application,
+    export_csv,
+    init_db,
+    list_applications,
+    render_table,
+    stats_by_status,
+)
+
+
+DEFAULT_DB = os.environ.get("JOBTRACKR_DB", "jobtrackr.db")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="jobtrackr",
+        description="Track your job applications from the command line.",
+    )
+    parser.add_argument("--db", default=DEFAULT_DB, help="Path to SQLite database file.")
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("init", help="Initialize the database.")
+
+    add_p = sub.add_parser("add", help="Add a new application.")
+    add_p.add_argument("--company", required=True)
+    add_p.add_argument("--role", required=True)
+    add_p.add_argument("--status", default="applied", choices=VALID_STATUSES)
+    add_p.add_argument("--date", default=None, help="Application date in YYYY-MM-DD format.")
+    add_p.add_argument("--notes", default="")
+
+    list_p = sub.add_parser("list", help="List applications.")
+    list_p.add_argument("--status", choices=VALID_STATUSES)
+    list_p.add_argument("--since", default=None, help="Show applications on/after YYYY-MM-DD.")
+
+    sub.add_parser("stats", help="Show status counts.")
+
+    export_p = sub.add_parser("export", help="Export applications to CSV.")
+    export_p.add_argument("--output", default="applications_export.csv")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        if args.command == "init":
+            init_db(args.db)
+            print(f"Initialized database at: {args.db}")
+            return 0
+
+        if args.command == "add":
+            app_id = add_application(
+                args.db,
+                company=args.company,
+                role=args.role,
+                status=args.status,
+                applied_on=args.date,
+                notes=args.notes,
+            )
+            print(f"Added application #{app_id}.")
+            return 0
+
+        if args.command == "list":
+            rows = list_applications(args.db, status=args.status, since=args.since)
+            print(render_table(rows))
+            return 0
+
+        if args.command == "stats":
+            total, grouped = stats_by_status(args.db)
+            print(f"Total applications: {total}")
+            if not grouped:
+                print("No status data yet.")
+                return 0
+            for status, count in grouped:
+                print(f"- {status}: {count}")
+            return 0
+
+        if args.command == "export":
+            count = export_csv(args.db, args.output)
+            print(f"Exported {count} application(s) to {args.output}")
+            return 0
+
+        parser.error("Unknown command")
+        return 2
+
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/jobtrackr/db.py
+++ b/jobtrackr/db.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import csv
+import sqlite3
+from datetime import date, datetime
+from pathlib import Path
+from typing import Iterable
+
+VALID_STATUSES = ("wishlist", "applied", "interview", "offer", "rejected")
+
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS applications (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    company TEXT NOT NULL,
+    role TEXT NOT NULL,
+    status TEXT NOT NULL,
+    applied_on TEXT NOT NULL,
+    notes TEXT,
+    created_at TEXT NOT NULL
+);
+"""
+
+
+def _connect(db_path: str) -> sqlite3.Connection:
+    Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db(db_path: str) -> None:
+    with _connect(db_path) as conn:
+        conn.executescript(SCHEMA_SQL)
+
+
+def validate_status(status: str) -> str:
+    if status not in VALID_STATUSES:
+        raise ValueError(
+            f"Invalid status '{status}'. Expected one of: {', '.join(VALID_STATUSES)}"
+        )
+    return status
+
+
+def validate_date_iso(date_value: str) -> str:
+    try:
+        date.fromisoformat(date_value)
+    except ValueError as exc:
+        raise ValueError("Date must be in YYYY-MM-DD format.") from exc
+    return date_value
+
+
+def add_application(
+    db_path: str,
+    *,
+    company: str,
+    role: str,
+    status: str = "applied",
+    applied_on: str | None = None,
+    notes: str = "",
+) -> int:
+    init_db(db_path)
+    status = validate_status(status)
+    if applied_on is None:
+        applied_on = date.today().isoformat()
+    validate_date_iso(applied_on)
+
+    with _connect(db_path) as conn:
+        cur = conn.execute(
+            """
+            INSERT INTO applications (company, role, status, applied_on, notes, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (company.strip(), role.strip(), status, applied_on, notes.strip(), datetime.utcnow().isoformat()),
+        )
+        return int(cur.lastrowid)
+
+
+def list_applications(
+    db_path: str,
+    *,
+    status: str | None = None,
+    since: str | None = None,
+) -> list[sqlite3.Row]:
+    init_db(db_path)
+    query = "SELECT id, company, role, status, applied_on, notes FROM applications"
+    clauses: list[str] = []
+    params: list[str] = []
+
+    if status:
+        validate_status(status)
+        clauses.append("status = ?")
+        params.append(status)
+    if since:
+        validate_date_iso(since)
+        clauses.append("applied_on >= ?")
+        params.append(since)
+
+    if clauses:
+        query += " WHERE " + " AND ".join(clauses)
+    query += " ORDER BY applied_on DESC, id DESC"
+
+    with _connect(db_path) as conn:
+        return list(conn.execute(query, params).fetchall())
+
+
+def stats_by_status(db_path: str) -> tuple[int, list[tuple[str, int]]]:
+    init_db(db_path)
+    with _connect(db_path) as conn:
+        total = int(conn.execute("SELECT COUNT(*) FROM applications").fetchone()[0])
+        rows = conn.execute(
+            """
+            SELECT status, COUNT(*) AS count
+            FROM applications
+            GROUP BY status
+            ORDER BY count DESC, status ASC
+            """
+        ).fetchall()
+
+    ordered = [(row[0], int(row[1])) for row in rows]
+    return total, ordered
+
+
+def export_csv(db_path: str, output_path: str) -> int:
+    rows = list_applications(db_path)
+    fieldnames = ["id", "company", "role", "status", "applied_on", "notes"]
+    with open(output_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({key: row[key] for key in fieldnames})
+    return len(rows)
+
+
+def render_table(rows: Iterable[sqlite3.Row]) -> str:
+    rows = list(rows)
+    if not rows:
+        return "No applications found."
+
+    headers = ["ID", "Company", "Role", "Status", "Applied On", "Notes"]
+    data = [
+        [
+            str(r["id"]),
+            r["company"],
+            r["role"],
+            r["status"],
+            r["applied_on"],
+            r["notes"] or "",
+        ]
+        for r in rows
+    ]
+
+    widths = [len(h) for h in headers]
+    for row in data:
+        for i, value in enumerate(row):
+            widths[i] = max(widths[i], len(value))
+
+    sep = "-+-".join("-" * w for w in widths)
+    top = " | ".join(h.ljust(widths[i]) for i, h in enumerate(headers))
+    body = [" | ".join(col.ljust(widths[i]) for i, col in enumerate(row)) for row in data]
+    return "\n".join([top, sep, *body])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "jobtrackr-cli"
+version = "0.1.0"
+description = "Simple CLI to track job applications with SQLite"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{name = "Your Name"}]
+
+[project.scripts]
+jobtrackr = "jobtrackr.cli:main"
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"

--- a/tests/test_jobtrackr.py
+++ b/tests/test_jobtrackr.py
@@ -1,0 +1,55 @@
+import csv
+import tempfile
+import unittest
+from pathlib import Path
+
+from jobtrackr.db import add_application, export_csv, list_applications, stats_by_status
+
+
+class JobTrackrTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.db_path = str(Path(self.tempdir.name) / "jobs.db")
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def test_add_and_list(self) -> None:
+        app_id = add_application(
+            self.db_path,
+            company="OpenAI",
+            role="Software Engineer",
+            status="applied",
+            applied_on="2026-04-03",
+            notes="Referral",
+        )
+        self.assertEqual(app_id, 1)
+
+        rows = list_applications(self.db_path)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["company"], "OpenAI")
+
+    def test_stats(self) -> None:
+        add_application(self.db_path, company="A", role="R1", status="applied", applied_on="2026-01-01")
+        add_application(self.db_path, company="B", role="R2", status="interview", applied_on="2026-01-02")
+        add_application(self.db_path, company="C", role="R3", status="applied", applied_on="2026-01-03")
+
+        total, grouped = stats_by_status(self.db_path)
+        self.assertEqual(total, 3)
+        self.assertIn(("applied", 2), grouped)
+        self.assertIn(("interview", 1), grouped)
+
+    def test_export_csv(self) -> None:
+        add_application(self.db_path, company="A", role="R1", status="applied", applied_on="2026-01-01")
+        output = Path(self.tempdir.name) / "out.csv"
+        count = export_csv(self.db_path, str(output))
+
+        self.assertEqual(count, 1)
+        with output.open("r", encoding="utf-8") as f:
+            rows = list(csv.DictReader(f))
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["company"], "A")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Description

- Add a new jobtrackr package with cli.py implementing a command-line interface (commands: init, add, list, stats, export) and __init__.py exporting cli and db.

- Implement SQLite-backed storage in jobtrackr/db.py with schema, helpers: init_db, add_application, list_applications, stats_by_status, export_csv, render_table, and validation for statuses and ISO dates.
- Add tests in tests/test_jobtrackr.py exercising add/list/stats/export flows using a temporary database.
- Add project metadata in pyproject.toml, a user-facing README.md, and a .gitignore for pycache, DBs, CSVs, and virtualenv files.